### PR TITLE
Add enumber::Into.

### DIFF
--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -30,6 +30,30 @@ pub enum LogLevel {
     Error = 0xc0..=0xff,
 }
 
+#[enumber::into]
+#[repr(usize)]
+#[derive(Debug)]
+enum IpAddr {
+    #[value(4)] V4(u8, u8, u8, u8),
+    #[value(6)] V6(String),
+}
+
+#[derive(Debug)]
+struct Fingerprint {
+    value: Box<[u8]>,
+}
+
+#[enumber::into]
+#[repr(usize)]
+#[derive(Debug)]
+enum Errors {
+    CannotLoadCryptoLibrary(String) = 0x110,
+    InitSqlite3WithoutMutex = 0x120,
+    AmbiguousName(String, String) = 0x202,
+    CannotDeleteKey(Fingerprint, String) = 0x212,
+}
+
+
 #[test]
 fn test_open_from_num_canfail() {
     assert!(OpenExample::try_from(45).is_err());
@@ -45,4 +69,24 @@ fn check_from_hex() {
         },
         Err(e) => panic!(e),
     }
+}
+
+#[test]
+fn test_ip_addr() {
+    assert_eq!(4 as usize, IpAddr::V4(192, 168, 1, 1).into());
+    assert_eq!(6 as usize, IpAddr::V6("1::".into()).into());
+}
+
+#[test]
+fn test_errors() {
+    assert_eq!(0x110 as usize,
+               Errors::CannotLoadCryptoLibrary("file not found".into()).into());
+    assert_eq!(0x120 as usize,
+               Errors::InitSqlite3WithoutMutex.into());
+    assert_eq!(0x202 as usize,
+               Errors::AmbiguousName("a".into(), "123".into()).into());
+    assert_eq!(0x212 as usize,
+               Errors::CannotDeleteKey(
+                   Fingerprint { value: b"1234".to_vec().into_boxed_slice() },
+                   "Key does not exists".into()).into());
 }


### PR DESCRIPTION
  - enumber::Convert converts between enums and values.  It can also
    be useful to just convert enumerations to values without
    converting values to enumerations.  For instance, this would allow
    enumber to support enumerations with variants that have data,
    whose values can't be inferred from the enumber value.

  - To support this, this change adds the `enumber::Into` macro, which
    only implements `From` for converting an enum into a value.

Signed-off-by: Neal H. Walfield <neal@pep.foundation>