### PR TITLE
Add a conversion From<&T> for N.

### DIFF
--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -100,3 +100,26 @@ fn test_errors() {
         .into()
     );
 }
+
+#[test]
+fn test_errors_refs() {
+    assert_eq!(
+        0x110_usize,
+        (&Errors::CannotLoadCryptoLibrary("file not found".into())).into()
+    );
+    assert_eq!(0x120_usize, (&Errors::InitSqlite3WithoutMutex).into());
+    assert_eq!(
+        0x202_usize,
+        (&Errors::AmbiguousName("a".into(), "123".into())).into()
+    );
+    assert_eq!(
+        0x212_usize,
+        (&Errors::CannotDeleteKey(
+            Fingerprint {
+                value: b"1234".to_vec().into_boxed_slice()
+            },
+            "Key does not exists".into()
+        ))
+        .into()
+    );
+}


### PR DESCRIPTION
  - Right now, there is an implementation of `From<T> for N`.

  - This is inconvenient when the caller wants to retain ownership of
    `T`, e.g., when `T` doesn't implement `Copy` or `Clone` or making
    a copy is expensive.

  - Synthesize an implementation of `From<&T> for N`.  Implement
    `From<T> for N` in terms of it.